### PR TITLE
Added expandable groupings for settings

### DIFF
--- a/app/src/main/java/edu/txstate/mobile/tracs/SettingsActivity.java
+++ b/app/src/main/java/edu/txstate/mobile/tracs/SettingsActivity.java
@@ -9,6 +9,7 @@ import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.ExpandableListView;
 import android.widget.ListView;
 import android.widget.Toast;
 
@@ -140,12 +141,11 @@ public class SettingsActivity extends AppCompatActivity implements Observer {
 
     private void displayListView() {
         findViewById(R.id.loading_spinner).setVisibility(View.GONE);
-        ListView settingsListView = (ListView) findViewById(R.id.settings_list);
-        adapter = new SettingsAdapter(this.siteNames, this);
+        ExpandableListView settingsListView = (ExpandableListView) findViewById(R.id.settings_list);
+        adapter = new SettingsAdapter(this, this.siteNames);
         settingsListView.setAdapter(adapter);
-        int size = settingsListView.getCount();
-        for (int i = 0; i < size; i++) {
-
+        for (int groupPosition = 0; groupPosition < adapter.getGroupCount(); groupPosition++) {
+            settingsListView.expandGroup(groupPosition);
         }
     }
 

--- a/app/src/main/res/layout/content_settings.xml
+++ b/app/src/main/res/layout/content_settings.xml
@@ -8,11 +8,10 @@
     tools:context="edu.txstate.mobile.tracs.SettingsActivity"
     tools:showIn="@layout/activity_notifications">
 
-    <ListView
+    <ExpandableListView
         android:id="@+id/settings_list"
         android:layout_width="match_parent"
         android:layout_height="match_parent" >
-
-    </ListView>
+    </ExpandableListView>
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/settings_header.xml
+++ b/app/src/main/res/layout/settings_header.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/settings_header"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:paddingLeft="?android:attr/expandableListPreferredItemPaddingLeft"
+        android:textSize="24sp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/settings_row.xml
+++ b/app/src/main/res/layout/settings_row.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<Switch xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/setting_toggle"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <Switch
+        android:id="@+id/setting_toggle"
+        android:layout_width="match_parent"
+        android:textSize="17sp"
+        android:layout_height="match_parent" />
+
+</LinearLayout>


### PR DESCRIPTION
I can't believe this worked nearly the first time through, but
settings are now in an expandable list. The default is to have
the list expanded, with collapse available if necessary. If there
is a way to group hidden, or mark them as hidden/inactive in the
app this could be used to hide them.