### PR TITLE
Fixed settings to send an appropriate object to Dispatch

### DIFF
--- a/app/src/main/java/edu/txstate/mobile/tracs/NotificationSettingsActivity.java
+++ b/app/src/main/java/edu/txstate/mobile/tracs/NotificationSettingsActivity.java
@@ -124,9 +124,8 @@ public class NotificationSettingsActivity extends BaseTracsActivity {
         String settingsUrl = context.getString(R.string.dispatch_base) +
                              context.getString(R.string.dispatch_settings);
 
-        //No tag needed, this request doesn't ever need to be cancelled.
         HttpQueue.getInstance(AnalyticsApplication.getContext()).addToRequestQueue(
                 new SettingsRequest(settingsUrl,
-                        response -> Toast.makeText(context, "Settings updated", Toast.LENGTH_SHORT).show()), null);
+                        response -> Toast.makeText(context, "Settings updated!", Toast.LENGTH_SHORT).show()), null);
     }
 }

--- a/app/src/main/java/edu/txstate/mobile/tracs/adapters/SettingsAdapter.java
+++ b/app/src/main/java/edu/txstate/mobile/tracs/adapters/SettingsAdapter.java
@@ -147,6 +147,7 @@ public class SettingsAdapter extends BaseExpandableListAdapter {
         rowHolder.settingStatus.setOnClickListener(this::onClicked);
 
         convertView.setTag(rowHolder);
+        SettingsStore.getInstance().put(rowHolder.settingId, rowHolder.settingStatus.isChecked());
 
         return convertView;
     }

--- a/app/src/main/java/edu/txstate/mobile/tracs/util/Registrar.java
+++ b/app/src/main/java/edu/txstate/mobile/tracs/util/Registrar.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 import edu.txstate.mobile.tracs.AnalyticsApplication;
 import edu.txstate.mobile.tracs.BuildConfig;
+import edu.txstate.mobile.tracs.R;
 import edu.txstate.mobile.tracs.util.http.HttpQueue;
 import edu.txstate.mobile.tracs.util.http.requests.DispatchRegistrationRequest;
 import edu.txstate.mobile.tracs.util.http.requests.JwtRequest;
@@ -22,8 +23,8 @@ public class Registrar {
     private Map<String, String> registration = new HashMap<>();
     private String jwt;
 
-    private static final String tokenUrl = "https://dispatchqa1.its.qual.txstate.edu:3000/token.pl";
-    private static final String dispatchUrl = "https://dispatchqa1.its.qual.txstate.edu/registrations";
+    private static final String TOKEN_URL = AnalyticsApplication.getContext().getString(R.string.jwt_url);
+    private static final String DISPATCH_URL = AnalyticsApplication.getContext().getString(R.string.dispatch_registration);
     private static final String TAG = "Registrar";
     private static Registrar registrar;
 
@@ -55,7 +56,7 @@ public class Registrar {
         HttpQueue requestQueue = HttpQueue.getInstance(AnalyticsApplication.getContext());
         Map<String, String> headers = new HashMap<>();
         requestQueue.addToRequestQueue(new JwtRequest(
-                tokenUrl,
+                TOKEN_URL,
                 headers,
                 Registrar.getInstance()::receiveJwt,
                 error -> Log.wtf(TAG, error.getMessage())
@@ -63,7 +64,7 @@ public class Registrar {
     }
 
     private void receiveJwt(String jwt) {
-        String url = dispatchUrl + "?jwt=" + jwt;
+        String url = DISPATCH_URL + "?jwt=" + jwt;
         HttpQueue requestQueue = HttpQueue.getInstance(AnalyticsApplication.getContext());
         JSONObject regInfo = Registrar.getInstance().getJsonRegistration();
         DispatchRegistrationRequest registerRequest = new DispatchRegistrationRequest(url, regInfo);

--- a/app/src/main/java/edu/txstate/mobile/tracs/util/SettingsStore.java
+++ b/app/src/main/java/edu/txstate/mobile/tracs/util/SettingsStore.java
@@ -5,7 +5,7 @@ import com.google.gson.JsonStreamParser;
 
 public class SettingsStore {
     private static final String TAG = "SettingsStore";
-    private final boolean DEFAULT_SETTING = true;
+    public static final boolean DEFAULT_SETTING = true;
     private JsonObject settings = new JsonObject();
 
     private static SettingsStore notificationSettings;

--- a/app/src/main/java/edu/txstate/mobile/tracs/util/http/requests/JwtRequest.java
+++ b/app/src/main/java/edu/txstate/mobile/tracs/util/http/requests/JwtRequest.java
@@ -32,7 +32,7 @@ public class JwtRequest extends StringRequest {
         SharedPreferences prefs = AnalyticsApplication.getContext().getSharedPreferences("cas", Context.MODE_PRIVATE);
         String userAgent = prefs.getString("user-agent", "");
         prefs.edit().remove("user-agent").apply();
-        this.headers.put("Cookie", cookies.getCookie(url).split("; ")[1]);
+        this.headers.put("Cookie", cookies.getCookie(url));
         this.headers.put("User-Agent", userAgent);
         return headers;
     }

--- a/app/src/main/java/edu/txstate/mobile/tracs/util/http/requests/UserSitesRequest.java
+++ b/app/src/main/java/edu/txstate/mobile/tracs/util/http/requests/UserSitesRequest.java
@@ -27,7 +27,7 @@ public class UserSitesRequest extends Request<LinkedHashMap<String, String>> {
     private Response.Listener<LinkedHashMap<String, String>> listener;
     private Response.ErrorListener errorListener;
     private static final String URL = AnalyticsApplication.getContext().getString(R.string.tracs_base) +
-            AnalyticsApplication.getContext().getString(R.string.user_sites_url);
+            AnalyticsApplication.getContext().getString(R.string.tracs_user_sites_url);
 
     public UserSitesRequest(Response.Listener<LinkedHashMap<String, String>> listener, Response.ErrorListener errorListener) {
         super(Method.GET, URL, errorListener);

--- a/app/src/main/res/values/urls.xml
+++ b/app/src/main/res/values/urls.xml
@@ -9,8 +9,12 @@
     <string name="tracs_site">direct/site/</string>
     <string name="tracs_portal">portal/pda</string>
     <string name="tracs_logout">https://login.its.txstate.edu/logout?service=https://staging.tracs.txstate.edu/sakai-login-tool/container</string>
+    <string name="tracs_user_sites_url">direct/membership.json</string>
+
     <string name="dispatch_base">https://dispatchqa1.its.qual.txstate.edu/</string>
     <string name="dispatch_notifications">notifications</string>
     <string name="dispatch_settings">settings</string>
-    <string name="user_sites_url">direct/membership.json</string>
+    <string name="dispatch_registration">https://dispatchqa1.its.qual.txstate.edu/registrations</string>
+
+    <string name="jwt_url">https://dispatchqa1.its.qual.txstate.edu:3000/token.pl</string>
 </resources>


### PR DESCRIPTION
The body of the post request was sending repeated keys and settings, and not
sending an appropriately empty object if all sites and types were enabled. This
was due to a logical error in how settings are instantiated when the screen is loaded.